### PR TITLE
Fix crash when annotations key set to None

### DIFF
--- a/kuma_ingress_watcher/controller.py
+++ b/kuma_ingress_watcher/controller.py
@@ -136,7 +136,7 @@ def get_routes_or_rules(spec, type_obj):
 
 def process_routing_object(item, type_obj):
     metadata = item["metadata"]
-    annotations = metadata.get("annotations", {})
+    annotations = metadata.get("annotations") or {}
 
     name = metadata["name"]
     namespace = metadata["namespace"]


### PR DESCRIPTION
Quick fix for an edge case I encountered

The returned Ingress object dict had annotations set to None:

```
{'api_version': None, 'kind': None, 'metadata': {'annotations': None, ... } ... }
```

Causing the error:

```
Traceback (most recent call last):
  File "/app/kuma_ingress_watcher/controller.py", line 374, in <module>
    main()
    ~~~~^^
  File "/app/kuma_ingress_watcher/controller.py", line 370, in main
    watch_ingress_resources()
    ~~~~~~~~~~~~~~~~~~~~~~~^^
  File "/app/kuma_ingress_watcher/controller.py", line 310, in watch_ingress_resources
    previous_ingress = handle_changes(
        previous_ingress, current_items, "Ingress"
    )
  File "/app/kuma_ingress_watcher/controller.py", line 264, in handle_changes
    process_routing_object(current_items[name], resource_type)
    ~~~~~~~~~~~~~~~~~~~~~~^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/app/kuma_ingress_watcher/controller.py", line 145, in process_routing_object
    interval = int(annotations.get("uptime-kuma.autodiscovery.probe.interval", 60))
                   ^^^^^^^^^^^^^^^
AttributeError: 'NoneType' object has no attribute 'get'
```