### PR TITLE
Add support for probe parent and statuscodes

### DIFF
--- a/tests/test_create_or_update_monitor.py
+++ b/tests/test_create_or_update_monitor.py
@@ -11,7 +11,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             {"name": "test", "url": "http://oldurl.com", "id": 1}
         ]
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", "testgroup", ["200-299"])
 
         mock_logger.info.assert_called_with(
             "Updating monitor for test with URL: http://newurl.com"
@@ -24,6 +24,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             headers=None,
             method="GET",
             parent=None,
+            accepted_statuscodes=["200-299"],
         )
 
     @patch("kuma_ingress_watcher.controller.kuma")
@@ -31,7 +32,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
     def test_create_or_update_monitor_create(self, mock_logger, mock_kuma):
         mock_kuma.get_monitors.return_value = []
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None, ["200-299"])
 
         mock_logger.info.assert_any_call(
             "Creating new monitor for test with URL: http://newurl.com"
@@ -45,6 +46,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             headers=None,
             method="GET",
             parent=None,
+            accepted_statuscodes=["200-299"],
         )
 
     @patch("kuma_ingress_watcher.controller.kuma")
@@ -68,6 +70,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             headers=None,
             method="GET",
             parent=1,
+            accepted_statuscodes=None,
         )
 
     @patch("kuma_ingress_watcher.controller.kuma")
@@ -75,7 +78,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
     def test_create_or_update_monitor_error(self, mock_logger, mock_kuma):
         mock_kuma.get_monitors.side_effect = Exception("API error")
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET")
 
         mock_logger.error.assert_called_once_with(
             "Failed to create or update monitor for test: API error"

--- a/tests/test_create_or_update_monitor.py
+++ b/tests/test_create_or_update_monitor.py
@@ -11,7 +11,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             {"name": "test", "url": "http://oldurl.com", "id": 1}
         ]
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET")
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
 
         mock_logger.info.assert_called_with(
             "Updating monitor for test with URL: http://newurl.com"
@@ -23,6 +23,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             type="http",
             headers=None,
             method="GET",
+            parent=None,
         )
 
     @patch("kuma_ingress_watcher.controller.kuma")
@@ -30,7 +31,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
     def test_create_or_update_monitor_create(self, mock_logger, mock_kuma):
         mock_kuma.get_monitors.return_value = []
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET")
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
 
         mock_logger.info.assert_any_call(
             "Creating new monitor for test with URL: http://newurl.com"
@@ -43,6 +44,30 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
             interval=60,
             headers=None,
             method="GET",
+            parent=None,
+        )
+
+    @patch("kuma_ingress_watcher.controller.kuma")
+    @patch("kuma_ingress_watcher.controller.logger")
+    def test_create_or_update_monitor_create_and_find_group(self, mock_logger, mock_kuma):
+        mock_kuma.get_monitors.return_value = [
+            {"name": "testgroup", "type": "group", "id": 1}
+        ]
+
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", "testgroup")
+
+        mock_logger.info.assert_any_call(
+            "Creating new monitor for test with URL: http://newurl.com"
+        )
+        mock_logger.info.assert_any_call("Successfully created monitor for test")
+        mock_kuma.add_monitor.assert_called_once_with(
+            type="http",
+            name="test",
+            url="http://newurl.com",
+            interval=60,
+            headers=None,
+            method="GET",
+            parent=1,
         )
 
     @patch("kuma_ingress_watcher.controller.kuma")
@@ -50,7 +75,7 @@ class TestCreateOrUpdateMonitor(unittest.TestCase):
     def test_create_or_update_monitor_error(self, mock_logger, mock_kuma):
         mock_kuma.get_monitors.side_effect = Exception("API error")
 
-        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET")
+        create_or_update_monitor("test", "http://newurl.com", 60, "http", None, "GET", None)
 
         mock_logger.error.assert_called_once_with(
             "Failed to create or update monitor for test: API error"

--- a/tests/test_process_file_monitor.py
+++ b/tests/test_process_file_monitor.py
@@ -54,6 +54,7 @@ class TestProcessFileIngress(unittest.TestCase):
           type: http
           headers: {"Authorization": "Bearer token"}
           method: POST
+          parent: test-parent
         """
         mock_open.return_value.__enter__.return_value.read.return_value = (
             mock_file_content
@@ -68,6 +69,7 @@ class TestProcessFileIngress(unittest.TestCase):
             "http",
             {"Authorization": "Bearer token"},
             "POST",
+            "test-parent",
         )
 
     @patch("kuma_ingress_watcher.controller.logger", spec=True)

--- a/tests/test_process_routes.py
+++ b/tests/test_process_routes.py
@@ -22,10 +22,11 @@ class TestProcessRoutes(unittest.TestCase):
             port="8080",
             method="GET",
             type_obj="IngressRoute",
+            parent="testgroup",
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com:8080", 60, "http", None, "GET"
+            "test-monitor", "https://example.com:8080", 60, "http", None, "GET", "testgroup"
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -49,15 +50,16 @@ class TestProcessRoutes(unittest.TestCase):
             port="8080",
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         self.assertEqual(mock_create_or_update_monitor.call_count, 2)
         calls = [
             unittest.mock.call(
-                "test-monitor-1", "https://example.com:8080", 60, "http", None, "GET"
+                "test-monitor-1", "https://example.com:8080", 60, "http", None, "GET", None
             ),
             unittest.mock.call(
-                "test-monitor-2", "https://example.org:8080", 60, "http", None, "GET"
+                "test-monitor-2", "https://example.org:8080", 60, "http", None, "GET", None
             ),
         ]
         mock_create_or_update_monitor.assert_has_calls(calls)
@@ -80,6 +82,7 @@ class TestProcessRoutes(unittest.TestCase):
             port="8080",
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         mock_create_or_update_monitor.assert_not_called()
@@ -102,10 +105,11 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com", 60, "http", None, "GET"
+            "test-monitor", "https://example.com", 60, "http", None, "GET", None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -126,10 +130,11 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com/milou", 60, "http", None, "GET"
+            "test-monitor", "https://example.com/milou", 60, "http", None, "GET", None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -150,10 +155,11 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://tintin/milou", 60, "http", None, "GET"
+            "test-monitor", "https://tintin/milou", 60, "http", None, "GET", None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -174,10 +180,11 @@ class TestProcessRoutes(unittest.TestCase):
             port=8080,
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://tintin/milou:8080", 60, "http", None, "GET"
+            "test-monitor", "https://tintin/milou:8080", 60, "http", None, "GET", None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -201,15 +208,16 @@ class TestProcessRoutes(unittest.TestCase):
             port=8080,
             method="GET",
             type_obj="IngressRoute",
+            parent=None,
         )
 
         self.assertEqual(mock_create_or_update_monitor.call_count, 2)
         calls = [
             unittest.mock.call(
-                "test-monitor-1", "https://tintin/milou:8080", 60, "http", None, "GET"
+                "test-monitor-1", "https://tintin/milou:8080", 60, "http", None, "GET", None
             ),
             unittest.mock.call(
-                "test-monitor-2", "https://tintin/milou:8080", 60, "http", None, "GET"
+                "test-monitor-2", "https://tintin/milou:8080", 60, "http", None, "GET", None
             ),
         ]
         mock_create_or_update_monitor.assert_has_calls(calls)

--- a/tests/test_process_routes.py
+++ b/tests/test_process_routes.py
@@ -23,10 +23,11 @@ class TestProcessRoutes(unittest.TestCase):
             method="GET",
             type_obj="IngressRoute",
             parent="testgroup",
+            accepted_statuscodes=["200-299"]
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com:8080", 60, "http", None, "GET", "testgroup"
+            "test-monitor", "https://example.com:8080", 60, "http", None, "GET", "testgroup", ["200-299"]
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -50,16 +51,15 @@ class TestProcessRoutes(unittest.TestCase):
             port="8080",
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         self.assertEqual(mock_create_or_update_monitor.call_count, 2)
         calls = [
             unittest.mock.call(
-                "test-monitor-1", "https://example.com:8080", 60, "http", None, "GET", None
+                "test-monitor-1", "https://example.com:8080", 60, "http", None, "GET", None, None
             ),
             unittest.mock.call(
-                "test-monitor-2", "https://example.org:8080", 60, "http", None, "GET", None
+                "test-monitor-2", "https://example.org:8080", 60, "http", None, "GET", None, None
             ),
         ]
         mock_create_or_update_monitor.assert_has_calls(calls)
@@ -82,7 +82,6 @@ class TestProcessRoutes(unittest.TestCase):
             port="8080",
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         mock_create_or_update_monitor.assert_not_called()
@@ -105,11 +104,10 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com", 60, "http", None, "GET", None
+            "test-monitor", "https://example.com", 60, "http", None, "GET", None, None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -130,11 +128,10 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://example.com/milou", 60, "http", None, "GET", None
+            "test-monitor", "https://example.com/milou", 60, "http", None, "GET", None, None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -155,11 +152,10 @@ class TestProcessRoutes(unittest.TestCase):
             port=None,
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://tintin/milou", 60, "http", None, "GET", None
+            "test-monitor", "https://tintin/milou", 60, "http", None, "GET", None, None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -180,11 +176,10 @@ class TestProcessRoutes(unittest.TestCase):
             port=8080,
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         mock_create_or_update_monitor.assert_called_once_with(
-            "test-monitor", "https://tintin/milou:8080", 60, "http", None, "GET", None
+            "test-monitor", "https://tintin/milou:8080", 60, "http", None, "GET", None, None
         )
 
     @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
@@ -208,16 +203,15 @@ class TestProcessRoutes(unittest.TestCase):
             port=8080,
             method="GET",
             type_obj="IngressRoute",
-            parent=None,
         )
 
         self.assertEqual(mock_create_or_update_monitor.call_count, 2)
         calls = [
             unittest.mock.call(
-                "test-monitor-1", "https://tintin/milou:8080", 60, "http", None, "GET", None
+                "test-monitor-1", "https://tintin/milou:8080", 60, "http", None, "GET", None, None
             ),
             unittest.mock.call(
-                "test-monitor-2", "https://tintin/milou:8080", 60, "http", None, "GET", None
+                "test-monitor-2", "https://tintin/milou:8080", 60, "http", None, "GET", None, None
             ),
         ]
         mock_create_or_update_monitor.assert_has_calls(calls)


### PR DESCRIPTION
Adding support for 2 new features that I was missing in this awesome project:

# Parent
Add probes to a group monitor (parent): very useful, eg to set notifications for the whole group in one place

Implemented:
 - Global parent variable (to be fetched from helm `values.yaml`)
 - Per-probe parent set in resource annotations
 - does NOT create the group in Kuma, only adds to it if it exists

# Accepted Statuscodes

Provide accepted status codes for given probe via annotations