### PR TITLE
Fix orphaned monitors when deleting multi-host Ingress/IngressRoute

### DIFF
--- a/kuma_ingress_watcher/controller.py
+++ b/kuma_ingress_watcher/controller.py
@@ -141,18 +141,47 @@ def get_routes_or_rules(spec, type_obj):
         return []
 
 
+def get_monitor_name(item):
+    metadata = item["metadata"]
+    annotations = metadata.get("annotations") or {}
+    name = metadata["name"]
+    namespace = metadata["namespace"]
+    return annotations.get(
+        "uptime-kuma.autodiscovery.probe.name", f"{name}-{namespace}"
+    )
+
+
+def get_monitor_names_for_object(item, type_obj):
+    monitor_name = get_monitor_name(item)
+    routes_or_rules = get_routes_or_rules(item["spec"], type_obj)
+
+    names = []
+    index = 1
+    for route_or_rule in routes_or_rules:
+        hosts = extract_hosts(route_or_rule, type_obj)
+
+        if hosts:
+            for host in hosts:
+                monitor_name_with_index = (
+                    f"{monitor_name}-{index}"
+                    if len(routes_or_rules) > 1
+                    else monitor_name
+                )
+                names.append(monitor_name_with_index)
+            index += 1
+
+    return names
+
+
 def process_routing_object(item, type_obj):
     metadata = item["metadata"]
     annotations = metadata.get("annotations") or {}
 
     name = metadata["name"]
-    namespace = metadata["namespace"]
     spec = item["spec"]
     routes_or_rules = get_routes_or_rules(spec, type_obj)
     interval = int(annotations.get("uptime-kuma.autodiscovery.probe.interval", 60))
-    monitor_name = annotations.get(
-        "uptime-kuma.autodiscovery.probe.name", f"{name}-{namespace}"
-    )
+    monitor_name = get_monitor_name(item)
     enabled = (
         annotations.get("uptime-kuma.autodiscovery.probe.enabled", "true").lower()
         == "true"
@@ -179,7 +208,8 @@ def process_routing_object(item, type_obj):
 
     if not enabled:
         logger.info(f"Monitoring for {name} is disabled via annotations.")
-        delete_monitor(monitor_name)
+        for name_to_delete in get_monitor_names_for_object(item, type_obj):
+            delete_monitor(name_to_delete)
         return
 
     process_routes(
@@ -289,10 +319,9 @@ def handle_changes(previous_items, current_items, resource_type):
 
     deleted = previous_names - current_names
     for name in deleted:
-        namespace = previous_items[name]["metadata"]["namespace"]
-        monitor_name = f"{name}-{namespace}"
         logger.info(f"{resource_type} {name} deleted.")
-        delete_monitor(monitor_name)
+        for monitor_name in get_monitor_names_for_object(previous_items[name], resource_type):
+            delete_monitor(monitor_name)
 
     modified = current_names & previous_names
     for name in modified:

--- a/tests/test_handle_changes.py
+++ b/tests/test_handle_changes.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, call
 from kuma_ingress_watcher.controller import handle_changes
 
 
@@ -15,14 +15,27 @@ class TestHandleChanges(unittest.TestCase):
         mock_delete_monitor,
         mock_process_routing_object,
     ):
-        # Define previous and current items
+        # Define previous and current items. test2 has a single rule/host, so it
+        # is expected to produce a single, unsuffixed monitor name.
         previous_items = {
-            "test1": {"metadata": {"name": "test1", "namespace": "default"}},
-            "test2": {"metadata": {"name": "test2", "namespace": "default"}},
+            "test1": {
+                "metadata": {"name": "test1", "namespace": "default"},
+                "spec": {"rules": [{"host": "test1.example.com"}]},
+            },
+            "test2": {
+                "metadata": {"name": "test2", "namespace": "default"},
+                "spec": {"rules": [{"host": "test2.example.com"}]},
+            },
         }
         current_items = {
-            "test1": {"metadata": {"name": "test1", "namespace": "default"}},
-            "test3": {"metadata": {"name": "test3", "namespace": "default"}},
+            "test1": {
+                "metadata": {"name": "test1", "namespace": "default"},
+                "spec": {"rules": [{"host": "test1.example.com"}]},
+            },
+            "test3": {
+                "metadata": {"name": "test3", "namespace": "default"},
+                "spec": {"rules": [{"host": "test3.example.com"}]},
+            },
         }
 
         # Simulate that the items have changed
@@ -39,6 +52,43 @@ class TestHandleChanges(unittest.TestCase):
 
         # Verify that delete_monitor was called for the deleted item
         mock_delete_monitor.assert_called_once_with("test2-default")
+
+    @patch("kuma_ingress_watcher.controller.process_routing_object")
+    @patch("kuma_ingress_watcher.controller.delete_monitor")
+    @patch("kuma_ingress_watcher.controller.ingressroute_changed")
+    @patch("kuma_ingress_watcher.controller.logger", spec=True)
+    def test_handle_changes_deletes_all_monitors_for_multi_host_ingress(
+        self,
+        mock_logger,
+        mock_ingressroute_changed,
+        mock_delete_monitor,
+        mock_process_routing_object,
+    ):
+        # A deleted Ingress with two rules/hosts previously produced two
+        # suffixed monitors (name-namespace-1, name-namespace-2). Regression
+        # test for https://github.com/SQuent/kuma-ingress-watcher/issues/60 -
+        # deletion must clean up every suffixed monitor, not just the
+        # unsuffixed base name.
+        previous_items = {
+            "multi": {
+                "metadata": {"name": "multi", "namespace": "default"},
+                "spec": {
+                    "rules": [
+                        {"host": "multi.local.example.com"},
+                        {"host": "multi.example.com"},
+                    ]
+                },
+            },
+        }
+        current_items = {}
+
+        handle_changes(previous_items, current_items, "Ingress")
+
+        mock_process_routing_object.assert_not_called()
+        mock_delete_monitor.assert_has_calls(
+            [call("multi-default-1"), call("multi-default-2")], any_order=True
+        )
+        self.assertEqual(mock_delete_monitor.call_count, 2)
 
 
 if __name__ == "__main__":

--- a/tests/test_process_routing_object.py
+++ b/tests/test_process_routing_object.py
@@ -1,5 +1,5 @@
 import unittest
-from unittest.mock import patch
+from unittest.mock import patch, call
 from kuma_ingress_watcher.controller import process_routing_object
 
 
@@ -69,6 +69,41 @@ class TestProcessRoutingObject(unittest.TestCase):
         mock_create_or_update_monitor.assert_not_called()
         # Verify that delete_monitor was not called
         mock_delete_monitor.assert_not_called()
+
+    @patch("kuma_ingress_watcher.controller.create_or_update_monitor")
+    @patch("kuma_ingress_watcher.controller.delete_monitor")
+    def test_process_routing_object_disabled_deletes_all_suffixed_monitors(
+        self, mock_delete_monitor, mock_create_or_update_monitor
+    ):
+        # An object with multiple routes/hosts that gets disabled via
+        # annotation must clean up every suffixed monitor it previously
+        # created (name-namespace-1, name-namespace-2, ...), not just the
+        # unsuffixed base name. See
+        # https://github.com/SQuent/kuma-ingress-watcher/issues/60
+        item = {
+            "metadata": {
+                "name": "test",
+                "namespace": "default",
+                "annotations": {
+                    "uptime-kuma.autodiscovery.probe.enabled": "false"
+                },
+            },
+            "spec": {
+                "routes": [
+                    {"match": "Host(`example.com`)"},
+                    {"match": "Host(`example.org`)"},
+                ]
+            },
+        }
+        type_obj = "IngressRoute"
+
+        process_routing_object(item, type_obj)
+
+        mock_create_or_update_monitor.assert_not_called()
+        mock_delete_monitor.assert_has_calls(
+            [call("test-default-1"), call("test-default-2")], any_order=True
+        )
+        self.assertEqual(mock_delete_monitor.call_count, 2)
 
 
 if __name__ == "__main__":


### PR DESCRIPTION
Fixes #60.

Ingresses with more than one host get monitors named `<name>-<namespace>-1`, `-2`, etc (see `process_routes`). Deletion never accounted for this, it only ever looked up `<name>-<namespace>`, so those monitors never got cleaned up.

To reproduce: create an Ingress with 2 hosts, then delete it. Watch the logs, you'll see `No monitor found with name <name>-<namespace>` and the `-1`/`-2` monitors stay orphaned in Uptime Kuma.

Fix pulls the name/suffix logic used in `process_routes` into `get_monitor_names_for_object()` and reuses it in both delete paths (`handle_changes` and the disabled-via-annotation branch of `process_routing_object`), so deletion looks up every monitor that was actually created, not just the base name.

Tested locally against a real cluster: built the image, ran it against Uptime Kuma, created a 2-host Ingress, confirmed both monitors got created, deleted the Ingress, confirmed both got deleted. Added a couple tests covering the multi-host delete case too.
